### PR TITLE
Removing duplicate ID

### DIFF
--- a/src/components/menus/footer-menu.js
+++ b/src/components/menus/footer-menu.js
@@ -3,7 +3,7 @@ import { Link } from 'gatsby';
 
 const FooterMenu = () => (
   <>
-    <h2 className="visually-hidden" id="footer">
+    <h2 className="visually-hidden">
       CivicActions footer menu</h2>
     <nav aria-labelledby="footer" className="footer__menu">
       <ul className="footer__menu--list">


### PR DESCRIPTION
Footer is already defined in:
src/components/footer.js

Shouldn't also be in the footer-menu.js

Title: WCAG 4.1.1: Ensures every id attribute value used in ARIA and in labels is unique (footer)
Tags: Accessibility, WCAG 4.1.1, duplicate-id-aria

Issue: Ensures every id attribute value used in ARIA and in labels is unique (duplicate-id-aria - https://accessibilityinsights.io/info-examples/web/duplicate-id-aria)

Target application: Home | CivicActions - https://beta.civicactions.com/

Element path: footer

Snippet: <footer id="footer" class="footer">

How to fix: 
Fix any of the following:
  Document has multiple elements referenced with ARIA with the same id attribute: footer

Environment: Microsoft Edge version 91.0.864.41

====

This accessibility issue was found using Accessibility Insights for Web 2.27.0 (axe-core 4.2.1), a tool that helps find and fix accessibility issues. Get more information & download this tool at http://aka.ms/AccessibilityInsights.